### PR TITLE
H265 support improvements

### DIFF
--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -1,0 +1,19 @@
+name: Add PR to Smackore project board, if the author is from outside Membrane Team
+on:
+  pull_request_target:
+    types:
+      - opened
+jobs:
+  maybe_add_to_project_board:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout membrane_core
+      uses: actions/checkout@v3
+      with:
+        repository: membraneframework/membrane_core
+    - name: Puts PR in "New PRs by community" column in the Smackore project, if the author is from outside Membrane Team
+      uses: ./.github/actions/add_pr_to_smackore_board
+      with:
+        GITHUB_TOKEN: ${{ secrets.MEMBRANEFRAMEWORKADMIN_TOKEN }}
+        AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+        PR_URL: ${{ github.event.pull_request.html_url }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package can be installed by adding `membrane_h264_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_h264_plugin, "~> 0.9.0"}
+    {:membrane_h264_plugin, "~> 0.9.1"}
   ]
 end
 ```

--- a/lib/membrane_h264_plugin/h264/decoder_configuration_record.ex
+++ b/lib/membrane_h264_plugin/h264/decoder_configuration_record.ex
@@ -5,8 +5,6 @@ defmodule Membrane.H264.DecoderConfigurationRecord do
   The structure of the record is described in section 5.2.4.1.1 of MPEG-4 part 15 (ISO/IEC 14496-15).
   """
 
-  alias Membrane.H264.Parser
-
   @enforce_keys [
     :spss,
     :ppss,
@@ -30,7 +28,7 @@ defmodule Membrane.H264.DecoderConfigurationRecord do
   @doc """
   Generates a DCR based on given PPSs and SPSs.
   """
-  @spec generate([binary()], [binary()], Parser.stream_structure()) ::
+  @spec generate([binary()], [binary()], Membrane.H26x.Parser.stream_structure()) ::
           binary() | nil
   def generate([], _ppss, _stream_structure) do
     nil

--- a/lib/membrane_h264_plugin/h264_parser.ex
+++ b/lib/membrane_h264_plugin/h264_parser.ex
@@ -43,14 +43,14 @@ defmodule Membrane.H264.Parser do
   (in-band).
   """
 
+  @behaviour Membrane.H26x.Parser
+
   use Membrane.Filter
 
   require Membrane.Logger
 
   alias Membrane.{H264, RemoteStream}
-  alias Membrane.H264.{DecoderConfigurationRecord, AUSplitter, NALuParser, AUTimestampGenerator}
-
-  @behaviour Membrane.H26x.Parser
+  alias Membrane.H264.{AUSplitter, AUTimestampGenerator, DecoderConfigurationRecord, NALuParser}
 
   @nalu_length_size 4
   @metadata_key :h264

--- a/lib/membrane_h264_plugin/h264_parser.ex
+++ b/lib/membrane_h264_plugin/h264_parser.ex
@@ -43,18 +43,21 @@ defmodule Membrane.H264.Parser do
   (in-band).
   """
 
-  use Membrane.H26x.Parser,
-    au_splitter: Membrane.H264.AUSplitter,
-    nalu_parser: Membrane.H264.NALuParser,
-    au_timestamp_generator: Membrane.H264.AUTimestampGenerator,
-    metadata_key: :h264
+  use Membrane.Filter
 
   require Membrane.Logger
 
   alias Membrane.{H264, RemoteStream}
-  alias Membrane.H264.DecoderConfigurationRecord
+  alias Membrane.H264.{DecoderConfigurationRecord, AUSplitter, NALuParser, AUTimestampGenerator}
+
+  @behaviour Membrane.H26x.Parser
 
   @nalu_length_size 4
+  @metadata_key :h264
+
+  @typep stream_format :: Membrane.StreamFormat.t()
+  @typep state :: Membrane.Element.state()
+  @typep callback_return :: Membrane.Element.Base.callback_return()
 
   def_input_pad :input,
     flow_control: :auto,
@@ -169,7 +172,34 @@ defmodule Membrane.H264.Parser do
       |> Map.put(:output_stream_structure, output_stream_structure)
       |> Map.put(:initial_parameter_sets, initial_parameter_sets)
 
-    super(ctx, opts)
+    Membrane.H26x.Parser.handle_init(
+      ctx,
+      opts,
+      AUTimestampGenerator,
+      NALuParser,
+      AUSplitter,
+      @metadata_key
+    )
+  end
+
+  @impl true
+  def handle_stream_format(:input, stream_format, ctx, state) do
+    Membrane.H26x.Parser.handle_stream_format(__MODULE__, stream_format, ctx, state)
+  end
+
+  @impl true
+  def handle_buffer(:input, %Membrane.Buffer{} = buffer, ctx, state) do
+    Membrane.H26x.Parser.handle_buffer(__MODULE__, buffer, ctx, state)
+  end
+
+  @impl true
+  def handle_end_of_stream(:input, ctx, state) when state.mode != :au_aligned do
+    Membrane.H26x.Parser.handle_end_of_stream(__MODULE__, ctx, state)
+  end
+
+  @impl true
+  def handle_end_of_stream(_pad, _ctx, state) do
+    {[end_of_stream: :output], state}
   end
 
   @impl true

--- a/lib/membrane_h264_plugin/h264_parser.ex
+++ b/lib/membrane_h264_plugin/h264_parser.ex
@@ -55,10 +55,6 @@ defmodule Membrane.H264.Parser do
   @nalu_length_size 4
   @metadata_key :h264
 
-  @typep stream_format :: Membrane.StreamFormat.t()
-  @typep state :: Membrane.Element.state()
-  @typep callback_return :: Membrane.Element.Base.callback_return()
-
   def_input_pad :input,
     flow_control: :auto,
     accepted_format: any_of(%RemoteStream{type: :bytestream}, H264)
@@ -175,6 +171,7 @@ defmodule Membrane.H264.Parser do
     Membrane.H26x.Parser.handle_init(
       ctx,
       opts,
+      __MODULE__,
       AUTimestampGenerator,
       NALuParser,
       AUSplitter,
@@ -184,17 +181,17 @@ defmodule Membrane.H264.Parser do
 
   @impl true
   def handle_stream_format(:input, stream_format, ctx, state) do
-    Membrane.H26x.Parser.handle_stream_format(__MODULE__, stream_format, ctx, state)
+    Membrane.H26x.Parser.handle_stream_format(stream_format, ctx, state)
   end
 
   @impl true
   def handle_buffer(:input, %Membrane.Buffer{} = buffer, ctx, state) do
-    Membrane.H26x.Parser.handle_buffer(__MODULE__, buffer, ctx, state)
+    Membrane.H26x.Parser.handle_buffer(buffer, ctx, state)
   end
 
   @impl true
   def handle_end_of_stream(:input, ctx, state) when state.mode != :au_aligned do
-    Membrane.H26x.Parser.handle_end_of_stream(__MODULE__, ctx, state)
+    Membrane.H26x.Parser.handle_end_of_stream(ctx, state)
   end
 
   @impl true

--- a/lib/membrane_h264_plugin/h265/decoder_configuration_record.ex
+++ b/lib/membrane_h264_plugin/h265/decoder_configuration_record.ex
@@ -5,7 +5,6 @@ defmodule Membrane.H265.DecoderConfigurationRecord do
   The structure of the record is described in section 8.3.3.1.1 of MPEG-4 part 15 (ISO/IEC 14496-15 Edition 2017-02).
   """
 
-  alias Membrane.H265.Parser
   alias Membrane.H26x.NALu
 
   @enforce_keys [
@@ -49,7 +48,8 @@ defmodule Membrane.H265.DecoderConfigurationRecord do
   @doc """
   Generates a DCR based on given PPSs, SPSs and VPSs.
   """
-  @spec generate([NALu.t()], [NALu.t()], [NALu.t()], Parser.stream_structure()) :: binary() | nil
+  @spec generate([NALu.t()], [NALu.t()], [NALu.t()], Membrane.H26x.Parser.stream_structure()) ::
+          binary() | nil
   def generate(_vpss, [], _ppss, _stream_structure) do
     nil
   end

--- a/lib/membrane_h264_plugin/h265/nalu_parser/schemes/sps.ex
+++ b/lib/membrane_h264_plugin/h265/nalu_parser/schemes/sps.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file Credo.Check.Refactor.Nesting
 defmodule Membrane.H265.NALuParser.Schemes.SPS do
   @moduledoc false
 

--- a/lib/membrane_h264_plugin/h265_parser.ex
+++ b/lib/membrane_h264_plugin/h265_parser.ex
@@ -30,14 +30,13 @@ defmodule Membrane.H265.Parser do
   * hev1, `:hev1` - The same as hvc1, only that parameter sets may be also present in the stream (in-band).
   """
 
+  @behaviour Membrane.H26x.Parser
   use Membrane.Filter
 
   require Membrane.H265.NALuTypes, as: NALuTypes
 
   alias Membrane.{H265, RemoteStream}
-  alias Membrane.H265.{DecoderConfigurationRecord, AUSplitter, NALuParser, AUTimestampGenerator}
-
-  @behaviour Membrane.H26x.Parser
+  alias Membrane.H265.{AUSplitter, AUTimestampGenerator, DecoderConfigurationRecord, NALuParser}
 
   @nalu_length_size 4
   @metadata_key :h265

--- a/lib/membrane_h264_plugin/h265_parser.ex
+++ b/lib/membrane_h264_plugin/h265_parser.ex
@@ -42,10 +42,6 @@ defmodule Membrane.H265.Parser do
   @nalu_length_size 4
   @metadata_key :h265
 
-  @typep stream_format :: Membrane.StreamFormat.t()
-  @typep state :: Membrane.Element.state()
-  @typep callback_return :: Membrane.Element.Base.callback_return()
-
   def_input_pad :input,
     flow_control: :auto,
     accepted_format: any_of(%RemoteStream{type: :bytestream}, H265)
@@ -180,6 +176,7 @@ defmodule Membrane.H265.Parser do
     Membrane.H26x.Parser.handle_init(
       ctx,
       opts,
+      __MODULE__,
       AUTimestampGenerator,
       NALuParser,
       AUSplitter,
@@ -189,17 +186,17 @@ defmodule Membrane.H265.Parser do
 
   @impl true
   def handle_stream_format(:input, stream_format, ctx, state) do
-    Membrane.H26x.Parser.handle_stream_format(__MODULE__, stream_format, ctx, state)
+    Membrane.H26x.Parser.handle_stream_format(stream_format, ctx, state)
   end
 
   @impl true
   def handle_buffer(:input, %Membrane.Buffer{} = buffer, ctx, state) do
-    Membrane.H26x.Parser.handle_buffer(__MODULE__, buffer, ctx, state)
+    Membrane.H26x.Parser.handle_buffer(buffer, ctx, state)
   end
 
   @impl true
   def handle_end_of_stream(:input, ctx, state) when state.mode != :au_aligned do
-    Membrane.H26x.Parser.handle_end_of_stream(__MODULE__, ctx, state)
+    Membrane.H26x.Parser.handle_end_of_stream(ctx, state)
   end
 
   @impl true

--- a/lib/membrane_h264_plugin/h26x_parser.ex
+++ b/lib/membrane_h264_plugin/h26x_parser.ex
@@ -5,7 +5,7 @@ defmodule Membrane.H26x.Parser do
   alias Membrane.H26x.{AUSplitter, NALuSplitter}
 
   @typedoc """
-  A type of a module implementing `Membrane.H26xParser` behaviour.
+  A type of a module implementing `Membrane.H26x.Parser` behaviour.
   """
   @type t :: module()
 

--- a/lib/membrane_h264_plugin/parser.ex
+++ b/lib/membrane_h264_plugin/parser.ex
@@ -305,7 +305,8 @@ defmodule Membrane.H264.Parser do
   end
 
   @impl true
-  def handle_end_of_stream(:input, ctx, state) when state.mode != :au_aligned do
+  def handle_end_of_stream(:input, ctx, state)
+      when state.mode != :au_aligned and ctx.pads.input.start_of_stream? do
     {last_nalu_payload, nalu_splitter} = NALuSplitter.split(<<>>, true, state.nalu_splitter)
     {last_nalu, nalu_parser} = NALuParser.parse_nalus(last_nalu_payload, state.nalu_parser)
     {maybe_improper_aus, au_splitter} = AUSplitter.split(last_nalu, true, state.au_splitter)

--- a/lib/membrane_h264_plugin/parser.ex
+++ b/lib/membrane_h264_plugin/parser.ex
@@ -59,225 +59,6 @@ defmodule Membrane.H26x.Parser do
   """
   @callback keyframe?(AUSplitter.access_unit()) :: boolean()
 
-  defmacro __using__(options) do
-    au_splitter = Keyword.fetch!(options, :au_splitter)
-    nalu_parser = Keyword.fetch!(options, :nalu_parser)
-    au_timestamp_generator = Keyword.fetch!(options, :au_timestamp_generator)
-    metadata_key = Keyword.fetch!(options, :metadata_key)
-
-    quote location: :keep do
-      use Membrane.Filter
-
-      @behaviour unquote(__MODULE__)
-
-      alias Membrane.Buffer
-      alias Membrane.Element.{Action, CallbackContext}
-      alias Membrane.H26x.{AUSplitter, NALu, NALuSplitter, Parser}
-
-      @typep stream_format :: Membrane.StreamFormat.t()
-      @typep state :: Membrane.Element.state()
-      @typep callback_return :: Membrane.Element.Base.callback_return()
-
-      @impl true
-      def handle_init(ctx, opts) do
-        Parser.handle_init(
-          ctx,
-          opts,
-          unquote(au_timestamp_generator),
-          unquote(nalu_parser),
-          unquote(au_splitter),
-          unquote(metadata_key)
-        )
-      end
-
-      @impl true
-      def handle_stream_format(:input, stream_format, ctx, state) do
-        {alignment, input_stream_structure, parameter_sets} =
-          parse_raw_input_stream_structure(stream_format)
-
-        is_first_received_stream_format = is_nil(ctx.pads.output.stream_format)
-
-        mode = Parser.get_mode_from_alignment(alignment)
-
-        state =
-          cond do
-            is_first_received_stream_format ->
-              output_stream_structure =
-                if is_nil(state.output_stream_structure),
-                  do: input_stream_structure,
-                  else: state.output_stream_structure
-
-              %{
-                state
-                | mode: mode,
-                  nalu_splitter: NALuSplitter.new(input_stream_structure),
-                  nalu_parser: state.nalu_parser_mod.new(input_stream_structure),
-                  input_stream_structure: input_stream_structure,
-                  output_stream_structure: output_stream_structure,
-                  framerate: Map.get(stream_format, :framerate) || state.framerate
-              }
-
-            not Parser.is_input_stream_structure_change_allowed?(
-              input_stream_structure,
-              state.input_stream_structure
-            ) ->
-              raise "stream structure cannot be fundamentally changed during stream"
-
-            mode != state.mode ->
-              {actions, state} = clean_state(state, ctx)
-              state = %{state | mode: mode}
-              {actions, state}
-
-            true ->
-              state
-          end
-
-        incoming_parameter_sets =
-          Parser.get_stream_format_parameter_sets(
-            input_stream_structure,
-            parameter_sets,
-            is_first_received_stream_format,
-            state
-          )
-
-        process_stream_format_parameter_sets(
-          incoming_parameter_sets,
-          ctx.pads.output.stream_format,
-          state
-        )
-      end
-
-      @impl true
-      def handle_buffer(:input, %Membrane.Buffer{} = buffer, ctx, state) do
-        {access_units, state} = Parser.handle_buffer(buffer, state)
-        prepare_actions_for_aus(access_units, ctx, state)
-      end
-
-      @impl true
-      def handle_end_of_stream(:input, ctx, state) when state.mode != :au_aligned do
-        {aus, state} = Parser.handle_end_of_stream(state)
-        {actions, state} = prepare_actions_for_aus(aus, ctx, state)
-        actions = if stream_format_sent?(actions, ctx), do: actions, else: []
-        {actions ++ [end_of_stream: :output], state}
-      end
-
-      @impl true
-      def handle_end_of_stream(_pad, _ctx, state) do
-        {[end_of_stream: :output], state}
-      end
-
-      @spec process_stream_format_parameter_sets(
-              unquote(__MODULE__).parameter_sets(),
-              stream_format() | nil,
-              state()
-            ) :: callback_return()
-      defp process_stream_format_parameter_sets(parameter_sets, stream_format, state) do
-        if remove_parameter_sets_from_stream?(state.output_stream_structure) do
-          {parsed_parameter_sets, nalu_parser} =
-            Enum.map_reduce(Tuple.to_list(parameter_sets), state.nalu_parser, fn ps,
-                                                                                 nalu_parser ->
-              state.nalu_parser_mod.parse_nalus(ps, {nil, nil}, false, nalu_parser)
-            end)
-
-          state = %{state | nalu_parser: nalu_parser}
-          process_new_parameter_sets(List.to_tuple(parsed_parameter_sets), stream_format, state)
-        else
-          frame_prefix =
-            state.nalu_parser_mod.prefix_nalus_payloads(
-              flatten_parameter_sets(parameter_sets),
-              state.input_stream_structure
-            )
-
-          {[], %{state | frame_prefix: frame_prefix}}
-        end
-      end
-
-      @spec process_new_parameter_sets(
-              unquote(__MODULE__).parameter_sets(),
-              stream_format() | nil,
-              state()
-            ) :: callback_return()
-      defp process_new_parameter_sets(parameter_sets, last_sent_stream_format, state) do
-        updated_parameter_sets =
-          Parser.merge_parameter_sets(parameter_sets, state.cached_parameter_sets)
-
-        state = %{state | cached_parameter_sets: updated_parameter_sets}
-
-        stream_format_candidate =
-          generate_stream_format(parameter_sets, last_sent_stream_format, state)
-
-        if stream_format_candidate in [last_sent_stream_format, nil] do
-          {[], state}
-        else
-          {[stream_format: {:output, stream_format_candidate}],
-           %{state | profile: stream_format_candidate.profile}}
-        end
-      end
-
-      @spec prepare_actions_for_aus([AUSplitter.access_unit()], CallbackContext.t(), state()) ::
-              callback_return()
-      defp prepare_actions_for_aus(aus, ctx, state) do
-        Enum.flat_map_reduce(aus, state, fn au, state ->
-          {au, stream_format, state} = process_au_parameter_sets(au, ctx, state)
-          {buffers_actions, state} = Parser.prepare_actions_for_aus(au, keyframe?(au), state)
-          {stream_format ++ buffers_actions, state}
-        end)
-      end
-
-      @spec process_au_parameter_sets(AUSplitter.access_unit(), CallbackContext.t(), state()) ::
-              {AUSplitter.access_unit(), [Action.t()], state()}
-      defp process_au_parameter_sets(au, ctx, state) do
-        old_stream_format = ctx.pads.output.stream_format
-        parameter_sets = get_parameter_sets(au)
-
-        {stream_format, state} =
-          process_new_parameter_sets(parameter_sets, old_stream_format, state)
-
-        au =
-          if remove_parameter_sets_from_stream?(state.output_stream_structure) do
-            Enum.filter(au, &(&1 not in flatten_parameter_sets(parameter_sets)))
-          else
-            maybe_add_parameter_sets(au, state)
-            |> delete_duplicate_parameter_sets(state)
-          end
-
-        {au, stream_format, state}
-      end
-
-      @spec maybe_add_parameter_sets(AUSplitter.access_unit(), state()) ::
-              AUSplitter.access_unit()
-      defp maybe_add_parameter_sets(au, %{repeat_parameter_sets: false}), do: au
-
-      defp maybe_add_parameter_sets(au, state) do
-        if keyframe?(au), do: flatten_parameter_sets(state.cached_parameter_sets) ++ au, else: au
-      end
-
-      @spec delete_duplicate_parameter_sets(AUSplitter.access_unit(), state()) ::
-              AUSplitter.access_unit()
-      defp delete_duplicate_parameter_sets(au, state) do
-        if keyframe?(au), do: Enum.uniq(au), else: au
-      end
-
-      @spec flatten_parameter_sets(unquote(__MODULE__).parameter_sets()) :: list()
-      defp flatten_parameter_sets(parameter_sets) do
-        Tuple.to_list(parameter_sets) |> List.flatten()
-      end
-
-      @spec stream_format_sent?([Action.t()], CallbackContext.t()) :: boolean()
-      defp stream_format_sent?(actions, %{pads: %{output: %{stream_format: nil}}}),
-        do: Enum.any?(actions, &match?({:stream_format, _stream_format}, &1))
-
-      defp stream_format_sent?(_actions, _ctx), do: true
-
-      defp clean_state(state, ctx) do
-        {access_units, state} = Parser.clean_state(state)
-        prepare_actions_for_aus(access_units, ctx, state)
-      end
-
-      defoverridable handle_init: 2
-    end
-  end
-
   @spec handle_init(map(), map(), module(), module(), module(), atom()) :: callback_return()
   def handle_init(_ctx, opts, au_timestamp_generator_mod, nalu_parser, au_splitter, metadata_key) do
     {au_timestamp_generator, framerate} =
@@ -310,8 +91,66 @@ defmodule Membrane.H26x.Parser do
     {[], state}
   end
 
-  @spec handle_buffer(Buffer.t(), state()) :: {[AUSplitter.access_unit()], state()}
-  def handle_buffer(%Buffer{} = buffer, state) do
+  def handle_stream_format(module, stream_format, ctx, state) do
+    {alignment, input_stream_structure, parameter_sets} =
+      module.parse_raw_input_stream_structure(stream_format)
+
+    is_first_received_stream_format = is_nil(ctx.pads.output.stream_format)
+
+    mode = get_mode_from_alignment(alignment)
+
+    state =
+      cond do
+        is_first_received_stream_format ->
+          output_stream_structure =
+            if is_nil(state.output_stream_structure),
+              do: input_stream_structure,
+              else: state.output_stream_structure
+
+          %{
+            state
+            | mode: mode,
+              nalu_splitter: NALuSplitter.new(input_stream_structure),
+              nalu_parser: state.nalu_parser_mod.new(input_stream_structure),
+              input_stream_structure: input_stream_structure,
+              output_stream_structure: output_stream_structure,
+              framerate: Map.get(stream_format, :framerate) || state.framerate
+          }
+
+        not is_input_stream_structure_change_allowed?(
+          input_stream_structure,
+          state.input_stream_structure
+        ) ->
+          raise "stream structure cannot be fundamentally changed during stream"
+
+        mode != state.mode ->
+          {actions, state} = clean_state(state)
+          state = %{state | mode: mode}
+          {actions, state}
+
+        true ->
+          state
+      end
+
+    incoming_parameter_sets =
+      get_stream_format_parameter_sets(
+        input_stream_structure,
+        parameter_sets,
+        is_first_received_stream_format,
+        state
+      )
+
+    process_stream_format_parameter_sets(
+      module,
+      incoming_parameter_sets,
+      ctx.pads.output.stream_format,
+      state
+    )
+  end
+
+  @spec handle_buffer(module(), Buffer.t(), CallbackContext.t(), state()) ::
+          {[AUSplitter.access_unit()], state()}
+  def handle_buffer(module, %Buffer{} = buffer, ctx, state) do
     {payload, state} =
       case state.frame_prefix do
         <<>> -> {buffer.payload, state}
@@ -333,18 +172,58 @@ defmodule Membrane.H26x.Parser do
     {access_units, au_splitter} =
       state.au_splitter_mod.split(nalus, is_au_aligned, state.au_splitter)
 
-    {access_units,
-     %{state | nalu_splitter: nalu_splitter, nalu_parser: nalu_parser, au_splitter: au_splitter}}
+    state = %{
+      state
+      | nalu_splitter: nalu_splitter,
+        nalu_parser: nalu_parser,
+        au_splitter: au_splitter
+    }
+
+    prepare_actions_for_aus(module, access_units, ctx, state)
   end
 
-  @spec handle_end_of_stream(state()) :: {[AUSplitter.access_unit()], state()}
-  def handle_end_of_stream(state) do
+  @spec handle_end_of_stream(module(), CallbackContext.t(), state()) :: callback_return()
+  def handle_end_of_stream(module, ctx, state) do
     {nalus_payloads, nalu_splitter} = NALuSplitter.split(<<>>, true, state.nalu_splitter)
     {nalus, nalu_parser} = state.nalu_parser_mod.parse_nalus(nalus_payloads, state.nalu_parser)
     {access_units, au_splitter} = state.au_splitter_mod.split(nalus, true, state.au_splitter)
 
-    {access_units,
-     %{state | nalu_splitter: nalu_splitter, nalu_parser: nalu_parser, au_splitter: au_splitter}}
+    state = %{
+      state
+      | nalu_splitter: nalu_splitter,
+        nalu_parser: nalu_parser,
+        au_splitter: au_splitter
+    }
+
+    {actions, state} = prepare_actions_for_aus(module, access_units, ctx, state)
+    actions = if stream_format_sent?(actions, ctx), do: actions, else: []
+    {actions ++ [end_of_stream: :output], state}
+  end
+
+  defp process_stream_format_parameter_sets(module, parameter_sets, stream_format, state) do
+    if module.remove_parameter_sets_from_stream?(state.output_stream_structure) do
+      {parsed_parameter_sets, nalu_parser} =
+        Enum.map_reduce(Tuple.to_list(parameter_sets), state.nalu_parser, fn ps, nalu_parser ->
+          state.nalu_parser_mod.parse_nalus(ps, {nil, nil}, false, nalu_parser)
+        end)
+
+      state = %{state | nalu_parser: nalu_parser}
+
+      process_new_parameter_sets(
+        module,
+        List.to_tuple(parsed_parameter_sets),
+        stream_format,
+        state
+      )
+    else
+      frame_prefix =
+        state.nalu_parser_mod.prefix_nalus_payloads(
+          flatten_parameter_sets(parameter_sets),
+          state.input_stream_structure
+        )
+
+      {[], %{state | frame_prefix: frame_prefix}}
+    end
   end
 
   @spec get_stream_format_parameter_sets(stream_structure(), parameter_sets(), boolean(), state()) ::
@@ -396,8 +275,64 @@ defmodule Membrane.H26x.Parser do
     |> List.to_tuple()
   end
 
-  @spec prepare_actions_for_aus(AUSplitter.access_unit(), boolean(), state()) :: callback_return()
-  def prepare_actions_for_aus(au, keyframe?, state) do
+  @spec prepare_actions_for_aus(
+          module(),
+          [AUSplitter.access_unit()],
+          CallbackContext.t(),
+          state()
+        ) ::
+          callback_return()
+  defp prepare_actions_for_aus(module, aus, ctx, state) do
+    Enum.flat_map_reduce(aus, state, fn au, state ->
+      {au, stream_format, state} = process_au_parameter_sets(module, au, ctx, state)
+      {buffers_actions, state} = prepare_actions_for_au(au, module.keyframe?(au), state)
+      {stream_format ++ buffers_actions, state}
+    end)
+  end
+
+  @spec process_au_parameter_sets(
+          module(),
+          AUSplitter.access_unit(),
+          CallbackContext.t(),
+          state()
+        ) ::
+          {AUSplitter.access_unit(), [Action.t()], state()}
+  defp process_au_parameter_sets(module, au, ctx, state) do
+    old_stream_format = ctx.pads.output.stream_format
+    parameter_sets = module.get_parameter_sets(au)
+
+    {stream_format, state} =
+      process_new_parameter_sets(module, parameter_sets, old_stream_format, state)
+
+    au =
+      if module.remove_parameter_sets_from_stream?(state.output_stream_structure) do
+        Enum.filter(au, &(&1 not in flatten_parameter_sets(parameter_sets)))
+      else
+        maybe_add_parameter_sets(module, au, state)
+        |> delete_duplicate_parameter_sets(module, state)
+      end
+
+    {au, stream_format, state}
+  end
+
+  @spec delete_duplicate_parameter_sets(AUSplitter.access_unit(), module(), state()) ::
+          AUSplitter.access_unit()
+  defp delete_duplicate_parameter_sets(au, module, _state) do
+    if module.keyframe?(au), do: Enum.uniq(au), else: au
+  end
+
+  @spec maybe_add_parameter_sets(module(), AUSplitter.access_unit(), state()) ::
+          AUSplitter.access_unit()
+  defp maybe_add_parameter_sets(_module, au, %{repeat_parameter_sets: false}), do: au
+
+  defp maybe_add_parameter_sets(module, au, state) do
+    if module.keyframe?(au),
+      do: flatten_parameter_sets(state.cached_parameter_sets) ++ au,
+      else: au
+  end
+
+  @spec prepare_actions_for_au(AUSplitter.access_unit(), boolean(), state()) :: callback_return()
+  def prepare_actions_for_au(au, keyframe?, state) do
     {{pts, dts}, state} = prepare_timestamps(au, state)
     {should_skip_au, state} = skip_au?(au, keyframe?, state)
 
@@ -411,6 +346,17 @@ defmodule Membrane.H26x.Parser do
 
     {buffers_actions, state}
   end
+
+  @spec flatten_parameter_sets(unquote(__MODULE__).parameter_sets()) :: list()
+  defp flatten_parameter_sets(parameter_sets) do
+    Tuple.to_list(parameter_sets) |> List.flatten()
+  end
+
+  @spec stream_format_sent?([Action.t()], CallbackContext.t()) :: boolean()
+  defp stream_format_sent?(actions, %{pads: %{output: %{stream_format: nil}}}),
+    do: Enum.any?(actions, &match?({:stream_format, _stream_format}, &1))
+
+  defp stream_format_sent?(_actions, _ctx), do: true
 
   @spec clean_state(state()) :: {[AUSplitter.access_unit()], state()}
   def clean_state(state) do
@@ -539,5 +485,22 @@ defmodule Membrane.H26x.Parser do
   defp empty_parameter_sets(parameter_sets) do
     Enum.map(1..tuple_size(parameter_sets), fn _id -> [] end)
     |> List.to_tuple()
+  end
+
+  defp process_new_parameter_sets(module, parameter_sets, last_sent_stream_format, state) do
+    updated_parameter_sets =
+      merge_parameter_sets(parameter_sets, state.cached_parameter_sets)
+
+    state = %{state | cached_parameter_sets: updated_parameter_sets}
+
+    stream_format_candidate =
+      module.generate_stream_format(parameter_sets, last_sent_stream_format, state)
+
+    if stream_format_candidate in [last_sent_stream_format, nil] do
+      {[], state}
+    else
+      {[stream_format: {:output, stream_format_candidate}],
+       %{state | profile: stream_format_candidate.profile}}
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,8 +1,8 @@
 defmodule Membrane.H264.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.9.0"
-  @github_url "https://github.com/membraneframework-labs/membrane_h264_plugin"
+  @version "0.9.1"
+  @github_url "https://github.com/membraneframework/membrane_h264_plugin"
 
   def project do
     [


### PR DESCRIPTION
This PR:
* removes the `Membrane.H26x.Parser.__using__` macro so that not to add private functions into the parser's implementation via macros
* changes the name of file with `Membrane.H26x.Parser` module so that to follow the naming convention
* implements newest changes from the main branch